### PR TITLE
Prevent warning in R 4.0.0 when plotting

### DIFF
--- a/spict/R/plotting.R
+++ b/spict/R/plotting.R
@@ -1228,7 +1228,7 @@ plotspict.fb <- function(rep, logax=FALSE, plot.legend=TRUE, man.legend=TRUE, ex
             cl <- numeric()
             class(cl) <- 'try-error'
         }
-        if (class(cl) == 'try-error'){
+        if (class(cl)[1] == 'try-error'){
             cl <- matrix(c(log(Bmsy[2]), log(Fmsy[2])), 1, 2)
         } 
         if (min(inp$dtc) < 1){ # Quarterly


### PR DESCRIPTION
Hi,
I just noticed that `plotspict.fb` generates a warning in R 4.0.0. To see the warning, simply run the help page example:
```
rep <- fit.spict(pol$albacore)
plotspict.fb(rep)

Warning message:
In if (class(cl) == "try-error") { :
  the condition has length > 1 and only the first element will be used
```
The source of the warning comes from this line:
https://github.com/DTUAqua/spict/blob/d9ece0a31623f1a26d3cb4328499f16136822d14/spict/R/plotting.R#L1231
In the typical case, `cl` is a matrix. In R 4.0.0 matrix objects are of class `"matrix" "array"` and therefore the length of `class(cl)` can be > 1.

This pull request takes the simplest approach to fix this warning by changing `class(cl)` to `class(cl)[1]`.