### PR TITLE
Correct check of `digits` argument in `summary.spcitcls` (closes #128)

### DIFF
--- a/spict/R/summary.R
+++ b/spict/R/summary.R
@@ -27,8 +27,7 @@
 #' summary(rep)
 #' @export
 summary.spictcls <- function(object, ...){
-    #object <- x
-    if(!exists('digits')) digits <- 7
+    if (!"digits" %in% names(list(...))) digits <- 7
     ndigits <- digits # Present values with this number of digits after the dot.
     rep <- object
     cat(paste('Convergence: ', rep$opt$convergence, '  MSG: ', rep$opt$message, '\n', sep=''))


### PR DESCRIPTION
The following examples were failing before:

#### Example 1
```
library(spict)
library(xtable)

fit <- fit.spict(pol$hake)
summary(fit)
```

#### Example 2
```
library(spict)
digits <- "1"

fit <- fit.spict(pol$hake)
summary(fit)
```